### PR TITLE
SockJS client doesn't need to disable heartbeats

### DIFF
--- a/priv/bunny.html
+++ b/priv/bunny.html
@@ -115,12 +115,6 @@ if (location.search == '?ws') {
 }
 var client = Stomp.over(ws);
 
-// SockJS does not support heart-beat: disable heart-beats
-if (location.search != '?ws') {
-    client.heartbeat.outgoing = 0;
-    client.heartbeat.incoming = 0;
-}
-
 client.debug = function() {
   if (window.console && console.log && console.log.apply) {
     console.log.apply(console, arguments);

--- a/priv/echo.html
+++ b/priv/echo.html
@@ -87,11 +87,6 @@
       }
       var client = Stomp.over(ws);
 
-      // SockJS does not support heart-beat: disable heart-beats
-      if (location.search != '?ws') {
-          client.heartbeat.outgoing = 0;
-          client.heartbeat.incoming = 0;
-      }
       client.debug = pipe('#second');
 
       var print_first = pipe('#first', function(data) {

--- a/priv/temp-queue.html
+++ b/priv/temp-queue.html
@@ -70,12 +70,6 @@
       }
       var client = Stomp.over(ws);
 
-      // SockJS does not support heart-beat: disable heart-beats
-      if (location.search != '?ws') {
-          client.heartbeat.incoming = 0;
-          client.heartbeat.outgoing = 0;
-      }
-
       client.debug = function(e) {
         $('#second div').append($("<code>").text(e));
       };


### PR DESCRIPTION
Now that the server disables heartbeats for SockJS on its end,
there is no need for the client to do it and we can use the STOMP
library's default.

Fix for https://github.com/rabbitmq/rabbitmq-web-stomp/issues/28