### PR TITLE
Change the pure Websocket example to send protocol header

### DIFF
--- a/priv/echo.html
+++ b/priv/echo.html
@@ -81,11 +81,11 @@
 
       // Stomp.js boilerplate
       if (location.search == '?ws') {
-          var ws = new WebSocket('ws://' + window.location.hostname + ':15674/ws');
+          var client = Stomp.client('ws://' + window.location.hostname + ':15674/ws');
       } else {
           var ws = new SockJS('http://' + window.location.hostname + ':15674/stomp');
+          var client = Stomp.over(ws);
       }
-      var client = Stomp.over(ws);
 
       client.debug = pipe('#second');
 


### PR DESCRIPTION
This change is not mandatory but it made it easier to test when the protocol header is set, as the client sends it but only if we didn't setup the Websocket connection beforehand.

Part of https://github.com/rabbitmq/rabbitmq-web-stomp/issues/53